### PR TITLE
32 add base layout templates

### DIFF
--- a/pages/templates/pages/test-base-fullscreen.html
+++ b/pages/templates/pages/test-base-fullscreen.html
@@ -1,0 +1,8 @@
+{% extends 'layouts/base-fullscreen.html' %}
+
+{% block title %}Home{% endblock title %}
+
+{% block content %}
+<h1>Base FullScreen</h1>
+
+{% endblock content %}

--- a/pages/urls.py
+++ b/pages/urls.py
@@ -11,5 +11,10 @@ urlpatterns = [
     path("terms/", views.TermsPageView.as_view(), name="terms"),
     path("privacy/", views.PrivacyPageView.as_view(), name="privacy"),
     path("contact/", views.ContactPageView.as_view(), name="contact"),
+    path(
+        "base-fullscreen/",
+        views.BaseFullscreenPageView.as_view(),
+        name="base-fullscreen",
+    ),
     path("favicon.ico", views.favicon),
 ]

--- a/pages/views.py
+++ b/pages/views.py
@@ -26,6 +26,10 @@ class PrivacyPageView(TemplateView):
     template_name: str = "pages/privacy.html"
 
 
+class BaseFullscreenPageView(TemplateView):
+    template_name: str = "pages/test-base-fullscreen.html"
+
+
 class ContactPageView(SuccessMessageMixin, FormView):
     template_name: str = "pages/contact.html"
     form_class = ContactForm

--- a/templates/layouts/base-fullscreen.html
+++ b/templates/layouts/base-fullscreen.html
@@ -1,0 +1,41 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>{% block title %}Educa{% endblock title %}</title>
+  <link rel="stylesheet" href="{% static 'css/base.css' %}">
+  <link rel="apple-touch-icon" sizes="180x180" href="{% static 'icons/apple-touch-icon.png' %}">
+  <link rel="icon" type="image/png" sizes="32x32" href="{% static 'icons/favicon-32x32.png' %}">
+  <link rel="icon" type="image/png" sizes="16x16" href="{% static 'icons/favicon-16x16.png' %}">
+  <link rel="manifest" href="{% static 'icons/site.webmanifest' %}">
+  <!-- Specific CSS goes HERE -->
+  {% block stylesheets %}{% endblock stylesheets %}
+
+</head>
+
+<body>
+  {% block header %}{% endblock header %}
+
+  <div id="content">
+    {% block content %}{% endblock content %}
+  </div>
+
+  <script src="https://code.jquery.com/jquery-3.6.1.min.js"
+    integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ=" crossorigin="anonymous"></script>
+  <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"
+    integrity="sha256-lSjKY0/srUM9BE3dPm+c4fBo1dky2v27Gdjm2uoZaL0=" crossorigin="anonymous"></script>
+  <script>
+        $(document).ready(function () {
+            {% block domready %}
+            {% endblock %}
+        });
+  </script>
+  {% block js %}{% endblock js %}
+
+</body>
+
+</html>


### PR DESCRIPTION
This PR introduces a base fullscreen layout template
which can be used for inheritance throughout the project.

A base full screen template is identical to a `base.html`
template except that we do not show

- header (navigation) bar
- footer bar

This could be useful in special pages like
- 404 Not found
- Throw some kind of server error
- Respond to broken links
- Respond to login / logout pages

Following are the commits
- "Implement base full screen layout 😉
- Hook up base full screen test url+view+template 😅
